### PR TITLE
Add Status to Foods Table

### DIFF
--- a/db/migrations/20170706132436_add-status-to-foods.js
+++ b/db/migrations/20170706132436_add-status-to-foods.js
@@ -1,0 +1,11 @@
+exports.up = function(knex, Promise) {
+  return knex.schema.table('foods', function(t){
+    t.enu('status', ['active', 'inactive']).defaultTo('active');
+  })
+};
+
+exports.down = function(knex, Promise) {
+  return knex.schema.table('foods', function(t){
+    t.dropColumn('status')
+  })
+};


### PR DESCRIPTION
@case-eee - here's the changes to add 'status' to our foods table! We used an enum for 'active' and 'inactive'. Also thought about doing a boolean, but wanted to try out an enum that has a default value of active.